### PR TITLE
Fix SC9 Rate I bill calculation function

### DIFF
--- a/SC9 I-III Calcs 7-16-2025/bill_calc.py
+++ b/SC9 I-III Calcs 7-16-2025/bill_calc.py
@@ -23,21 +23,25 @@ def string_to_list(s):
         return None
 
 def calculate_bill(
-    demand,
-    usage_kwh,
+    billing_df: pd.DataFrame,
+    usage_kwh: float,
     start_date,
     end_date,
-    rate_data
+    rate_data: dict,
+    contract_demand_kW: float = 0.0,
 ):
     """
     Calculate a detailed electric delivery bill based on as-used demand and energy usage.
 
     Parameters:
-    - demand (float): Billed demand
+    - billing_df (pd.DataFrame): DataFrame containing as-used demand data with
+      ``Date`` and demand columns.
     - usage_kwh (float): Total energy usage during billing period
     - start_date (str or datetime): Billing period start date
     - end_date (str or datetime): Billing period end date
-    - rate_data (dict): Rate structure extracted via extract_rate_data
+    - rate_data (dict): Rate structure extracted via ``extract_rate_data``
+    - contract_demand_kW (float, optional): Contract demand in kW used for the
+      contract demand charge calculation.
 
     Returns:
     - dict: Itemized breakdown of charges and total bill


### PR DESCRIPTION
## Summary
- refactor `calculate_bill` signature
- allow passing billing dataframe and contract demand

## Testing
- `python -m py_compile 'SC9 I-III Calcs 7-16-2025/bill_calc.py'`

------
https://chatgpt.com/codex/tasks/task_e_68781817d530832bbd71f8f4a0612722